### PR TITLE
remove cdnizer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ var config = {
       },
       s3UploadOptions: {
         Bucket: 'MyBucket'
-      },
-      cdnizerOptions: {
-        defaultCDNBase: 'http://asdf.ca'
       }
     })
   ]
@@ -207,9 +204,6 @@ var config = {
 - `basePath`: Provide the namespace of uploaded files on S3
 - `directory`: Provide a directory to upload (if not supplied, will upload js/css from compilation)
 - `htmlFiles`: Html files to cdnize (defaults to all in output directory)
-- `cdnizerCss`: Config for css cdnizer check below
-- `noCdnizer`: Disable cdnizer (defaults to true if no cdnizerOptions passed)
-- `cdnizerOptions`: options to pass to [cdnizer](https://www.npmjs.com/package/cdnizer)
 - `basePathTransform`: transform the base path to add a folder name. Can return a promise or a string
 - `progress`: Enable progress bar (defaults true)
 - `priority`: priority order to your files as regex array. The ones not matched by regex are uploaded first. This rule becomes useful when avoiding s3 eventual consistency issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,33 +1615,6 @@
       "integrity": "sha512-h04kV/lcuhItU1CZTJOxUEk/9R+1XeJqgc67E+XC8J9TjPM8kzVgOn27ZtRdDUo8O5F8U4QRCzDWJrVym3w3Cg==",
       "dev": true
     },
-    "cdnizer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cdnizer/-/cdnizer-3.0.2.tgz",
-      "integrity": "sha512-XTBGCv61pn9r8o/HDkUlPLv9hQ1bx0maWj07UdIU1VV/2P5KAswN9OEHPu6Tz7C5zMXIywdERtpCw0osQYm1ZA==",
-      "requires": {
-        "cdnjs-cdn-data": "^0.1.1",
-        "google-cdn-data": "^0.1.6",
-        "jsdelivr-cdn-data": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
-        "lodash": "^4.17.11",
-        "minimatch": "^3.0.2"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
-      }
-    },
-    "cdnjs-cdn-data": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cdnjs-cdn-data/-/cdnjs-cdn-data-0.1.2.tgz",
-      "integrity": "sha1-hl00uk5I3Rtz/WaOJKYaWt+biyE=",
-      "requires": {
-        "semver": "~5.0.1"
-      }
-    },
     "chai": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
@@ -3741,11 +3714,6 @@
         }
       }
     },
-    "google-cdn-data": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/google-cdn-data/-/google-cdn-data-0.1.25.tgz",
-      "integrity": "sha1-nDwxSasYp8LV7V8PC07ovEWZK3E="
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -4483,20 +4451,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^2.6.0"
-      }
-    },
-    "jsdelivr-cdn-data": {
-      "version": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
-      "from": "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0",
-      "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-        }
       }
     },
     "jsesc": {
@@ -6578,11 +6532,6 @@
           "dev": true
         }
       }
-    },
-    "semver": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
     },
     "serialize-javascript": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "webpack-s3-plugin",
+  "name": "@mxmul/webpack-s3-plugin",
   "version": "1.0.3",
   "description": "Uploads compiled assets to s3 after build",
   "main": "dist/s3_plugin.js",
   "scripts": {
     "build": "webpack --mode production",
-    "prepublishOnly": "npm run lint && npm run test && npm run build",
+    "prepublishOnly": "npm run build",
     "test": "NODE_ENV='test' mocha -t 10000 --require babel-register",
     "lint": "eslint ./src ./test",
     "watch": "webpack --watch --mode development",
@@ -32,7 +32,6 @@
   "homepage": "https://github.com/webpack-contrib/s3-plugin-webpack",
   "dependencies": {
     "aws-sdk": "^2.282.1",
-    "cdnizer": "^3.0.2",
     "lodash": "^4.17.10",
     "mime": "^2.3.1",
     "progress": "^2.0.0",

--- a/test/upload_test.js
+++ b/test/upload_test.js
@@ -207,46 +207,6 @@ describe('S3 Webpack Upload', function() {
       })
   })
 
-  it('cdnizes links inside of html files', function() {
-    var s3Config = {
-      cdnizerOptions: {
-        defaultCDNBase: testHelpers.S3_URL
-      }
-    }
-
-    var config = testHelpers.createWebpackConfig({s3Config})
-
-    return testHelpers.runWebpackConfig({config})
-      .then(testForErrorsOrGetFileNames)
-      .then(fileNames => Promise.resolve(fileNames.filter(name => /.*\.html$/.test(name))))
-      .then(function([htmlFile]) {
-        var outputFile = testHelpers.readFileFromOutputDir(htmlFile),
-            s3UrlRegex = new RegExp(testHelpers.S3_URL, 'gi')
-
-        return assert.match(outputFile, s3UrlRegex, `Url not changed to ${testHelpers.S3_URL}`)
-      })
-  })
-
-  it('cdnizes links inside of CSS files', function() {
-    var s3Config = {
-      cdnizerOptions: {
-        defaultCDNBase: testHelpers.S3_URL
-      }
-    }
-
-    var config = testHelpers.createWebpackConfig({s3Config})
-
-    return testHelpers.runWebpackConfig({config})
-      .then(testForErrorsOrGetFileNames)
-      .then(fileNames => Promise.resolve(fileNames.filter(name => /.*\.css$/.test(name))))
-      .then(function([file]) {
-        var outputFile = testHelpers.readFileFromOutputDir(file),
-            s3UrlRegex = new RegExp(testHelpers.S3_URL, 'gi')
-
-        return assert.match(outputFile, s3UrlRegex, `Url not changed to ${testHelpers.S3_URL}`)
-      })
-  })
-
   it('allows functions to be used for "s3UploadOptions"', function() {
     const Bucket = sinon.spy(() => S3Opts.AWS_BUCKET)
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -44,7 +44,6 @@ var config = {
   },
 
   externals: NODE_ENV === 'test' ? [] : [
-    'cdnizer',
     'aws-sdk',
     'lodash',
     's3',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,22 +1032,6 @@ caniuse-lite@^1.0.30000844:
   version "1.0.30000877"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz#f189673b86ecc06436520e3e391de6a13ca923b4"
 
-cdnizer@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/cdnizer/-/cdnizer-3.0.2.tgz#03f9f1664b1b43a20135f88d5e420e330408ab2d"
-  dependencies:
-    cdnjs-cdn-data "^0.1.1"
-    google-cdn-data "^0.1.6"
-    jsdelivr-cdn-data "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0"
-    lodash "^4.17.11"
-    minimatch "^3.0.2"
-
-cdnjs-cdn-data@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cdnjs-cdn-data/-/cdnjs-cdn-data-0.1.2.tgz#865d34ba4e48dd1b73fd668e24a61a5adf9b8b21"
-  dependencies:
-    semver "~5.0.1"
-
 chai@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
@@ -2130,10 +2114,6 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-cdn-data@^0.1.6:
-  version "0.1.25"
-  resolved "https://registry.yarnpkg.com/google-cdn-data/-/google-cdn-data-0.1.25.tgz#9c3c3149ab18a7c2d5ed5f0f0b4ee8bc45992b71"
-
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -2614,13 +2594,6 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-"jsdelivr-cdn-data@git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0":
-  version "1.0.0"
-  uid d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0
-  resolved "git://github.com/shahata/jsdelivr-cdn-data.git#d014a2ad1bdfb4c6e3d3cefc7f264435281b91e0"
-  dependencies:
-    semver "^5.3.0"
-
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -2748,7 +2721,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
 
@@ -3988,10 +3961,6 @@ schema-utils@^0.4.4, schema-utils@^0.4.5:
 semver@^5.3.0, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
-
-semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
 serialize-javascript@^1.4.0:
   version "1.5.0"


### PR DESCRIPTION
cdnizer has dependencies that are not fetched from the NPM registry, and
are not safe to use with some private NPM registries